### PR TITLE
Fix scripted tests

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,2 +1,2 @@
-addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.2")
-addSbtPlugin("de.heikoseeberger" % "sbt-header" % "5.10.0")
+addSbtPlugin("org.scalameta"     % "sbt-scalafmt" % "2.5.2")
+addSbtPlugin("de.heikoseeberger" % "sbt-header"   % "5.10.0")

--- a/sbt-protofetch/src/main/scala/com/coralogix/sbtprotofetch/ProtofetchBinary.scala
+++ b/sbt-protofetch/src/main/scala/com/coralogix/sbtprotofetch/ProtofetchBinary.scala
@@ -29,7 +29,7 @@ import java.util
 
 object ProtofetchBinary {
 
-  val DEFAULT_VERSION = "0.1.1"
+  val DEFAULT_VERSION = "0.1.8"
 
   def download(
       logger: Logger,

--- a/sbt-protofetch/src/main/scala/com/coralogix/sbtprotofetch/ProtofetchPlugin.scala
+++ b/sbt-protofetch/src/main/scala/com/coralogix/sbtprotofetch/ProtofetchPlugin.scala
@@ -55,11 +55,12 @@ object ProtofetchPlugin extends AutoPlugin {
   )
 
   override lazy val projectSettings: Seq[Setting[_]] = Seq(
-    protofetchModuleFile := baseDirectory.value / "protofetch.toml",
+    protofetchModuleFile            := baseDirectory.value / "protofetch.toml",
+    protofetchFetch / baseDirectory := protofetchModuleFile.value.getParentFile,
     protofetchLockFile := protofetchModuleFile.value.getParentFile / "protofetch.lock",
     protofetchOutputDirectory := {
-      val moduleFile = protofetchModuleFile.value
-      moduleFile.getParentFile / Protofetch.getOutputDirectory(moduleFile)
+      (protofetchFetch / baseDirectory).value /
+        Protofetch.getOutputDirectory(protofetchModuleFile.value)
     },
     protofetchFetch / insideCI := insideCI.value,
     protofetchFetch := {
@@ -69,6 +70,7 @@ object ProtofetchPlugin extends AutoPlugin {
       val s              = streams.value
       val binaryFileInfo = FileInfo.lastModified(protofetchBinary.value)
       val moduleFileInfo = FileInfo.hash(protofetchModuleFile.value)
+      val base           = (protofetchFetch / baseDirectory).value;
       val lockFile       = protofetchLockFile.value
       val locked         = (protofetchFetch / insideCI).value
 
@@ -76,7 +78,7 @@ object ProtofetchPlugin extends AutoPlugin {
         (changed, _: (Inputs, Outputs)) =>
           if (changed) {
             Protofetch.fetch(
-              baseDirectory.value,
+              base,
               s.log,
               binaryFileInfo.file,
               moduleFileInfo.file,


### PR DESCRIPTION
## Description

1. Update protofetch to 0.1.8
2. Fix scripted tests. Previously some tests were failing because the output directory expected by the plugin (calculated relative to the module file) was different from what protofetch actually uses (relative to the project base). 

Fixes # (issue)

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## How Has This Been Tested?


`sbt scripted`

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
