### PR TITLE
Disable Scala Steward for scala-library

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -1,0 +1,4 @@
+updates.ignore = [
+    # Scala version is tied to the sbt version
+    { groupId = "org.scala-lang", artifactId = "scala-library" }
+]


### PR DESCRIPTION
## Description

Scala Steward tries to update scala 2.12 to 2.13, but we have to stay on 2.12 because of sbt.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## How Has This Been Tested?


Not tested

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
