### PR TITLE
Bump default protofetch version to 0.1.21

### DIFF
--- a/sbt-protofetch/src/main/scala/com/coralogix/sbtprotofetch/ProtofetchBinary.scala
+++ b/sbt-protofetch/src/main/scala/com/coralogix/sbtprotofetch/ProtofetchBinary.scala
@@ -30,7 +30,7 @@ import scala.util.Random
 
 object ProtofetchBinary {
 
-  val DEFAULT_VERSION = "0.1.15"
+  val DEFAULT_VERSION = "0.1.21"
 
   def download(
       logger: Logger,


### PR DESCRIPTION
## What
Bumps `ProtofetchBinary.DEFAULT_VERSION` from `0.1.15` to `0.1.21`.

## Why
`0.1.15` has a worktree cache bug. When two modules in one `protofetch.toml` resolve to the **same repository and commit**, `create_worktree` keys the worktree directory by module name but keys the git worktree entry by commit hash inside a shared bare repo. The second module then fails to canonicalize its not-yet-created directory:

```
ERROR Error while canonicalizing path <cache>/dependencies/<module>/<hash>: No such file or directory (os error 2)
```

Fixed upstream in **protofetch 0.1.18** (protofetch PR #207); this bumps the plugin default to 0.1.21.

## Impact
Only the default changes. Consumers that set `protofetchVersion` are unaffected. `ProtofetchBinaryTest` uses the `DEFAULT_VERSION` symbol, so it needs no change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)