### PR TITLE
PLTU-108: Validate publish credentials before release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,6 +81,39 @@ jobs:
           tar xf targets.tar
           rm targets.tar
 
+      - name: Validate release credentials
+        env:
+          PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
+          PGP_SECRET: ${{ secrets.PGP_SECRET }}
+          SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
+          SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
+        run: |
+          set -euo pipefail
+
+          for name in PGP_PASSPHRASE PGP_SECRET SONATYPE_PASSWORD SONATYPE_USERNAME; do
+            if [[ -z "${!name}" ]]; then
+              echo "::error::$name is not configured"
+              exit 1
+            fi
+          done
+
+          if [[ "$PGP_SECRET" == *$'\n'* || "$PGP_SECRET" == *$'\r'* || "$PGP_SECRET" == *'%'* ]]; then
+            echo "::error::PGP_SECRET must be a single-line base64 value without a shell prompt character"
+            exit 1
+          fi
+
+          if [[ ! "$PGP_SECRET" =~ ^[A-Za-z0-9+/]+=*$ ]]; then
+            echo "::error::PGP_SECRET contains characters that are not valid base64"
+            exit 1
+          fi
+
+          if ! printf '%s' "$PGP_SECRET" \
+            | base64 --decode \
+            | gpg --batch --import-options show-only --import >/dev/null 2>&1; then
+            echo "::error::PGP_SECRET is not a valid base64-encoded private GPG key"
+            exit 1
+          fi
+
       - name: Publish project
         run: sbt ci-release
         env:


### PR DESCRIPTION
## What

Adds a release-credential preflight before `sbt ci-release`.

The check verifies that:

- all required release secrets are present;
- `PGP_SECRET` is a single-line base64 value without accidental shell characters;
- the decoded value is a valid private GPG key.

Secret contents are never printed.

## Why

Publish job [90865053772](https://github.com/coralogix/sbt-protofetch/actions/runs/30540652345/job/90865053772) failed with:

```
base64: invalid input
```

The failure occurs during `sbt-ci-release` GPG setup, before signing or Sonatype publishing. The underlying organization-level `PGP_SECRET` still needs to be re-encoded by its owner; this PR makes future failures actionable without changing publishing behavior.

## Validation

- YAML parse check passed.
- Shell syntax check passed.
- Synthetic valid private-key encoding passed.
- Synthetic trailing-`%`, wrapped, and raw armored-key inputs were rejected.
- `git diff --check` passed.

## Follow-up

After the organization-level `PGP_SECRET` is repaired, rerun the failed publish job for `v0.1.2`.